### PR TITLE
Add automatic job service docs

### DIFF
--- a/.github/workflows/job-service-docs.yml
+++ b/.github/workflows/job-service-docs.yml
@@ -2,7 +2,7 @@ name: Generate Job Service Docs
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
     paths:
       - 'src/job-service.ts'
       - 'src/lib/jobs/**'
@@ -32,4 +32,4 @@ jobs:
             git push
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BE_GH_REPO_KEY }}

--- a/.github/workflows/job-service-docs.yml
+++ b/.github/workflows/job-service-docs.yml
@@ -1,0 +1,35 @@
+name: Generate Job Service Docs
+
+on:
+  push:
+    branches: [ develop ]
+    paths:
+      - 'src/job-service.ts'
+      - 'src/lib/jobs/**'
+      - 'src/lib/db/schema/jobs.ts'
+      - '.github/workflows/job-service-docs.yml'
+      - 'scripts/generate-job-service-docs.js'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Generate documentation
+        run: node scripts/generate-job-service-docs.js
+      - name: Commit documentation
+        run: |
+          if [ -n "$(git status --porcelain docs/README_Jobs_API.md)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add docs/README_Jobs_API.md
+            git commit -m "chore: update job service docs"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/README_Jobs_API.md
+++ b/docs/README_Jobs_API.md
@@ -1,0 +1,87 @@
+# Job Service API
+
+This file is generated automatically by a GitHub action. Do not edit manually.
+
+## defineJob
+Register a job handler.
+
+```typescript
+function defineJob(type: string, handler: JobHandler): any
+```
+
+## startJobQueue
+Start the job queue polling loop.
+
+```typescript
+function startJobQueue(): Promise<any>
+```
+
+## getJob
+Retrieve a job by id.
+
+```typescript
+function getJob(id: string): Promise<any>
+```
+
+## getJobsByOrganisation
+List jobs for an organisation.
+
+```typescript
+function getJobsByOrganisation(organisationId: string, options?: {
+  status?: JobStatus;
+  type?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<any>
+```
+
+## createJob
+Create a new job.
+
+```typescript
+function createJob(type: string, metadata: any, organisationId: string): Promise<any>
+```
+
+## updateJobProgress
+Update progress information of a job.
+
+```typescript
+function updateJobProgress(id: string, progress: number): Promise<any>
+```
+
+## cancelJob
+Cancel a pending or running job.
+
+```typescript
+function cancelJob(id: string): Promise<any>
+```
+
+## Interfaces
+
+```typescript
+export interface JobHandlerRegister {
+  type: string;
+  handler: JobHandler;
+}
+```
+
+```typescript
+interface JobHandler {
+  execute: (metadata: any, job: Job) => Promise<any>;
+  onError?: (error: Error) => Promise<any>;
+  onCancel?: (job: Job) => Promise<any>;
+}
+```
+
+```typescript
+export type JobStatus = "pending" | "running" | "completed" | "failed";
+```
+
+```typescript
+export type Job = typeof jobs.$inferSelect;
+```
+
+```typescript
+export type NewJob = typeof jobs.$inferInsert;
+```
+

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "clean": "rm -rf ./lib/",
     "release:patch": "tsc && npm version patch && git push --follow-tags && npm publish",
     "release:minor": "tsc && npm version minor && git push --follow-tags && npm publish",
-    "release:major": "tsc && npm version major && git push --follow-tags && npm publish"
+    "release:major": "tsc && npm version major && git push --follow-tags && npm publish",
+    "generate:job-docs": "node scripts/generate-job-service-docs.js"
   },
   "types": "./lib/index.d.ts",
   "dependencies": {

--- a/scripts/generate-job-service-docs.js
+++ b/scripts/generate-job-service-docs.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+
+const FILE = 'src/lib/jobs/index.ts';
+const JOB_SCHEMA_FILE = 'src/lib/db/schema/jobs.ts';
+const OUTPUT = 'docs/README_Jobs_API.md';
+
+const DESCRIPTIONS = {
+  defineJob: 'Register a job handler.',
+  startJobQueue: 'Start the job queue polling loop.',
+  getJob: 'Retrieve a job by id.',
+  getJobsByOrganisation: 'List jobs for an organisation.',
+  createJob: 'Create a new job.',
+  updateJobProgress: 'Update progress information of a job.',
+  cancelJob: 'Cancel a pending or running job.'
+};
+
+function collectInterfaces(content, interfaces) {
+  let m;
+  const regexInterfaceExport = /^export\s+interface\s+(\w+)\s*{[^}]*}/gm;
+  while ((m = regexInterfaceExport.exec(content))) {
+    interfaces[m[1]] = m[0].trim();
+  }
+  const regexInterface = /^interface\s+(\w+)\s*{[^}]*}/gm;
+  while ((m = regexInterface.exec(content))) {
+    interfaces[m[1]] = m[0].trim();
+  }
+  const regexType = /^export\s+type\s+(\w+)\s*=\s*[^;]+;/gm;
+  while ((m = regexType.exec(content))) {
+    interfaces[m[1]] = m[0].trim();
+  }
+}
+
+const interfaces = {};
+collectInterfaces(fs.readFileSync(FILE, 'utf8'), interfaces);
+collectInterfaces(fs.readFileSync(JOB_SCHEMA_FILE, 'utf8'), interfaces);
+
+const file = fs.readFileSync(FILE, 'utf8');
+const funcRegex = /^export\s+(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)/gm;
+const functions = [];
+let m;
+while ((m = funcRegex.exec(file))) {
+  const name = m[1];
+  const params = m[2]
+    .split(',')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+  const async = m[0].includes('async');
+  functions.push({ name, params, async });
+}
+
+let md = '# Job Service API\n\n';
+md += 'This file is generated automatically by a GitHub action. Do not edit manually.\n\n';
+
+for (const fn of functions) {
+  md += `## ${fn.name}\n`;
+  if (DESCRIPTIONS[fn.name]) md += DESCRIPTIONS[fn.name] + '\n\n';
+  const paramStr = fn.params.join(', ');
+  md += '```typescript\n';
+  md += `function ${fn.name}(${paramStr}): ${fn.async ? 'Promise<any>' : 'any'}`;
+  md += '\n```\n\n';
+}
+
+if (Object.keys(interfaces).length) {
+  md += '## Interfaces\n\n';
+  for (const name of Object.keys(interfaces)) {
+    md += '```typescript\n' + interfaces[name] + '\n```\n\n';
+  }
+}
+
+fs.writeFileSync(OUTPUT, md);


### PR DESCRIPTION
## Summary
- generate markdown docs for job service
- add workflow to publish docs on push to develop
- expose a package script to regenerate docs

## Testing
- `node scripts/generate-job-service-docs.js`
- `bun test` *(fails: Cannot find module 'drizzle-orm', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68409bf6f6f0832784e795a0dc00e135